### PR TITLE
[Bugfix] コメント機能の不備などのバグ修正

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -43,8 +43,8 @@ class Admin::SessionsController < Devise::SessionsController
     # パスワードが一致しているか確認して、無ければdeviseに返して拒否してもらう
     return unless admin.valid_password?(params[:admin][:password])
     # 退会・除名状態でなければdeviseに返してサインイン成立
-    return if admin.is_active
-    flash[:notice] = admin.is_forbidden ? '除名済みの管理者です。' : '退会済みの管理者です。'
+    return if admin.available?
+    flash[:alert] = admin.is_forbidden ? '除名済みの管理者です。' : '退会済みの管理者です。'
     redirect_to new_admin_session_path
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   # エンドユーザーの除名・退会判定
   def deny_deactivated_user
-    return if current_user.is_active
+    return if current_user.available?
     flash[:notice] = current_user.is_forbidden ? '除名済みのアカウントです。' : '退会済みのアカウントです。'
     sign_out(current_user)
     redirect_to new_user_registration_path
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
  
   # 管理者の除名・退会判定
   def deny_deactivated_admin
-    return if current_admin.is_active
+    return if current_admin.available?
     flash[:notice] = current_admin.is_forbidden ? '除名済みの管理者です。' : '退会済みの管理者です。'
     sign_out(current_admin)
     redirect_to root_path

--- a/app/controllers/public/likes_controller.rb
+++ b/app/controllers/public/likes_controller.rb
@@ -6,7 +6,7 @@ class Public::LikesController < ApplicationController
   
   def create
     like = current_user.likes.new(post_id: @post.id)
-    like.save # NOT NULL制約があるため分岐不要
+    like.save # UNIQUE制約があるため分岐不要
     respond_to do |format|
       if params[:from_page] == 'posts_show'
         format.js { render :create_at_posts_show }

--- a/app/controllers/public/post_comments_controller.rb
+++ b/app/controllers/public/post_comments_controller.rb
@@ -22,10 +22,11 @@ class Public::PostCommentsController < ApplicationController
   end
 
   def destroy
-    comment = PostComment.find(params[:id])
-    if comment.user_id == current_user.id
-      comment.destroy # コメントしたユーザーでない場合は実行しない
+    comment = PostComment.find_by(id: params[:id], user_id: current_user.id)
+    if comment&.destroy
       flash[:notice_of_comment] = 'コメントを削除しました。'
+    else
+      flash[:notice_of_comment] = 'コメントが存在しないか、削除できません。'
     end
     # 再表示に必要なインスタンス変数の宣言
     @post_comment = PostComment.new

--- a/app/controllers/public/relationships_controller.rb
+++ b/app/controllers/public/relationships_controller.rb
@@ -8,7 +8,7 @@ class Public::RelationshipsController < ApplicationController
     if @user.id != current_user.id && @user.is_active # 自分自身と、退会済ユーザーはフォローできない
       # current_user.followers.newで「follower_user_idカラムにcurrent_user.idが入ったデータ」を作成する
       new_relationship = current_user.followers.new(followed_user_id: params[:user_id])
-      new_relationship.save # NOT NULL制約があるため分岐不要
+      new_relationship.save # UNIQUE制約があるため分岐不要
     end
     respond_to do |format|
       if params[:from_page] == 'users_show'

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -49,7 +49,7 @@ class Public::SessionsController < Devise::SessionsController
     # パスワードが一致しているか確認して、無ければdeviseに返して拒否してもらう
     return unless user.valid_password?(params[:user][:password])
     # 退会・除名状態でなければdeviseに返してサインイン成立
-    return if user.is_active
+    return if user.available?
     flash[:alert] = user.is_forbidden ? '除名済みのアカウントです。' : '退会済みのアカウントです。'
     redirect_to new_user_session_path
   end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -10,4 +10,8 @@ class Admin < ApplicationRecord
 
   validates :name, uniqueness: true, length: {minimum: 2, maximum: 20}
   validates :introduction, length: {maximum: 200}
+
+  def available?
+    is_active && !is_forbidden
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,10 @@ class User < ApplicationRecord
   scope :active, -> { where(is_active: true) }
   scope :except_guest, -> { where.not(email: 'guest@guest') }
 
+  def available?
+    is_active && !is_forbidden
+  end
+
   # プロフィール画像用
   def get_profile_image(width, height)
     # unless profile_image.attached?

--- a/app/views/public/_users.html.erb
+++ b/app/views/public/_users.html.erb
@@ -36,7 +36,7 @@
             <%= user.introduction %>
           </div>
           <div class="mb-2">
-            <%= user.posts.count %> ポスト / <%= user.followeds.count %> フォロー / <%= user.followers.count %> フォロワー
+            <%= user.posts.count %> ポスト / <%= user.followers.count %> フォロー / <%= user.followeds.count %> フォロワー
           </div>
         </div>
       </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -130,7 +130,7 @@ Admin.create!(
   name: '除名副管理者',
   introduction: '除名されたサブ管理者',
   main_admin: false,
-  is_active: true,
+  is_active: false,
   is_forbidden: true
 )
 


### PR DESCRIPTION
- 削除済みのコメントに対して削除を行った時にNoMethodErrorになる不具合を修正
- public/_usersの部分テンプレートでフォロー数とフォロワー数が逆だった不具合を修正
- seedのデータ誤りを修正
- ログインと会員・管理者限定の操作の権限を変更
  - is_activeに加えて!is_forbiddenを要求する仕様としました
- コメントの誤謬を訂正